### PR TITLE
Fixed drawSpline missing last point issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -339,14 +339,19 @@ export function Viewer(data, parent, width, height, font) {
         var interpolatedPoints = [];
         var curve;
         if (entity.degreeOfSplineCurve === 2 || entity.degreeOfSplineCurve === 3) {
-            for(var i = 0; i + 2 < points.length; i = i + 2) {
-        if (entity.degreeOfSplineCurve === 2) {
-                        curve = new THREE.QuadraticBezierCurve(points[i], points[i + 1], points[i + 2]);
-        } else {
-            curve = new THREE.QuadraticBezierCurve3(points[i], points[i + 1], points[i + 2]);
-        }
+            var i = 0
+	    for(i = 0; i + 2 < points.length; i = i + 2) {
+		if (entity.degreeOfSplineCurve === 2) {
+		    curve = new THREE.QuadraticBezierCurve(points[i], points[i + 1], points[i + 2]);
+		} else {
+		    curve = new THREE.QuadraticBezierCurve3(points[i], points[i + 1], points[i + 2]);
+		}
                 interpolatedPoints.push.apply(interpolatedPoints, curve.getPoints(50));
             }
+	    if (i < points.length) {
+		curve = new THREE.QuadraticBezierCurve3(points[i], points[i + 1], points[i + 1]);
+                interpolatedPoints.push.apply(interpolatedPoints, curve.getPoints(50));
+	    }
         } else {
             curve = new THREE.SplineCurve(points);
             interpolatedPoints = curve.getPoints( 100 );


### PR DESCRIPTION
Current strategy of drawSpline may miss the last part of curve when the length of points is a even number. 
For example, if the length of points is 14, the code will stop at i = 12 which i + 2 is not < point.length. Therefore, the curve between points[12] and points[13] is missing.

The code added will fix the issue.