### PR TITLE
fix: solve and issue with missing webpack-merge dependency on build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "license": "MIT",
   "devDependencies": {
     "webpack": "^4.29.5",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.2.3",
+    "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
     "three": "0.x.x"


### PR DESCRIPTION
Solves the issue with #61.

---
Same as [pull 62](https://github.com/gdsestimating/three-dxf/pull/62) without the unnecessary commits.