### PR TITLE
Fix `Error: Cannot find module 'THREE'`

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,6 +10,6 @@ module.exports = {
         globalObject: 'typeof self !== \'undefined\' ? self : this'
     },
     externals: {
-        three: 'THREE'
+        three: 'three'
     },
 };


### PR DESCRIPTION
I'm getting this error when bundling my app

```
Error: Cannot find module 'THREE'
```

The solution was to map the module to `three` as it's in the [npm](https://www.npmjs.com/package/three) module, instead of `THREE` that I believe it only works if importing the `<script>` directly