### PR TITLE
z position for arc elements defaults to 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -519,7 +519,7 @@ export function Viewer(data, parent, width, height, font) {
         var arc = new THREE.Line(geometry, material);
         arc.position.x = entity.center.x;
         arc.position.y = entity.center.y;
-        arc.position.z = entity.center.z;
+        arc.position.z = entity.center.z || 0;
 
         return arc;
     }


### PR DESCRIPTION
in some dxf files I regognized that the z position for arc elements is not set. In this case the library is not able to show the dxf file. If not set, the default is set to 0.